### PR TITLE
Replace log with logrus

### DIFF
--- a/nomad/data_source_acl_policies.go
+++ b/nomad/data_source_acl_policies.go
@@ -5,7 +5,7 @@ package nomad
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/nomad/data_source_acl_policy.go
+++ b/nomad/data_source_acl_policy.go
@@ -5,7 +5,7 @@ package nomad
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/nomad/api"

--- a/nomad/data_source_acl_role.go
+++ b/nomad/data_source_acl_role.go
@@ -5,7 +5,7 @@ package nomad
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/nomad/data_source_acl_token.go
+++ b/nomad/data_source_acl_token.go
@@ -5,7 +5,7 @@ package nomad
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 	"time"
 

--- a/nomad/data_source_deployments.go
+++ b/nomad/data_source_deployments.go
@@ -5,7 +5,7 @@ package nomad
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 	"strings"
 

--- a/nomad/data_source_job_parser.go
+++ b/nomad/data_source_job_parser.go
@@ -6,7 +6,7 @@ package nomad
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/nomad/data_source_namespaces.go
+++ b/nomad/data_source_namespaces.go
@@ -5,7 +5,7 @@ package nomad
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )

--- a/nomad/data_source_plugins.go
+++ b/nomad/data_source_plugins.go
@@ -5,7 +5,7 @@ package nomad
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/nomad/data_source_regions.go
+++ b/nomad/data_source_regions.go
@@ -5,7 +5,7 @@ package nomad
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )

--- a/nomad/data_source_volumes.go
+++ b/nomad/data_source_volumes.go
@@ -5,7 +5,7 @@ package nomad
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 
 	"github.com/hashicorp/nomad/api"

--- a/nomad/datasource_nomad_job.go
+++ b/nomad/datasource_nomad_job.go
@@ -5,7 +5,7 @@ package nomad
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/nomad/api"

--- a/nomad/datasource_nomad_plugin.go
+++ b/nomad/datasource_nomad_plugin.go
@@ -5,7 +5,7 @@ package nomad
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/nomad/api"

--- a/nomad/resource_acl_policy.go
+++ b/nomad/resource_acl_policy.go
@@ -5,7 +5,7 @@ package nomad
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/nomad/api"

--- a/nomad/resource_acl_role.go
+++ b/nomad/resource_acl_role.go
@@ -5,7 +5,7 @@ package nomad
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/nomad/api"

--- a/nomad/resource_acl_token.go
+++ b/nomad/resource_acl_token.go
@@ -5,7 +5,7 @@ package nomad
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 	"time"
 

--- a/nomad/resource_external_volume.go
+++ b/nomad/resource_external_volume.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"hash/crc32"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/dustin/go-humanize"
 	"github.com/hashicorp/nomad/api"

--- a/nomad/resource_job.go
+++ b/nomad/resource_job.go
@@ -6,7 +6,7 @@ package nomad
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"sort"
 	"strconv"

--- a/nomad/resource_namespace.go
+++ b/nomad/resource_namespace.go
@@ -5,7 +5,7 @@ package nomad
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 	"time"
 

--- a/nomad/resource_quota_specification.go
+++ b/nomad/resource_quota_specification.go
@@ -5,7 +5,7 @@ package nomad
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/nomad/api"

--- a/nomad/resource_scheduler_config.go
+++ b/nomad/resource_scheduler_config.go
@@ -6,7 +6,7 @@ package nomad
 import (
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/nomad/resource_scheduler_config_test.go
+++ b/nomad/resource_scheduler_config_test.go
@@ -4,7 +4,7 @@
 package nomad
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"testing"
 
 	"github.com/hashicorp/nomad/api"

--- a/nomad/resource_sentinel_policy.go
+++ b/nomad/resource_sentinel_policy.go
@@ -5,7 +5,7 @@ package nomad
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/nomad/api"

--- a/nomad/resource_volume.go
+++ b/nomad/resource_volume.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"hash/crc32"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/nomad/api"


### PR DESCRIPTION
stdout: Namespace(repository='github.com/sourcegraph-ce/terraform-provider-nomad', batch_change_name='log-provider-go-with-python-script-2', description='This batch change opens a PR for each .go file in a terraform provider repository, and replaces the standard library "log" import statement with the "logrus" library.  This batch change for each repository where the import "log" statement is replaced with "logrus".\n', secret='supersecret', reopen=False)
.release
scripts
.github
website
nomad
.git
workflows
ISSUE_TEMPLATE
docs
r
d
test-fixtures
helper
pointer
objects
info
branches
logs
refs
hooks
97
1b
94
99
9f
4e
6e
b0
01
1e
e4
d0
1c
11
22
1f
53
7a
07
fa
87
81
52
8e
ba
f2
ec
69
42
a3
ea
ff
bf
76
34
60
1d
c9
ca
26
06
d2
85
fd
82
9b
fb
b4
cb
c1
0f
74
93
61
cf
d1
c7
de
2a
pack
9a
d7
3a
ae
e0
be
info
f8
80
e5
ed
a7
3c
1a
a5
7d
fc
09
50
6d
7e
0c
c0
d5
a8
35
16
b1
40
67
aa
ab
3d
e1
b9
4f
54
0d
2f
55
63
77
c4
f9
04
64
b2
7b
6a
5d
bb
2d
58
f4
03
25
6f
df
90
refs
heads
tags
heads

[_Created by Sourcegraph batch change `admin/log-provider-go-with-python-script-2`._](https://gcp.s0urcegraph.com/users/admin/batch-changes/log-provider-go-with-python-script-2)